### PR TITLE
feat:  add eslint comment rules

### DIFF
--- a/configs/base.mjs
+++ b/configs/base.mjs
@@ -1,9 +1,11 @@
 import stylistic from '@stylistic/eslint-plugin';
 import eslintJs from '@eslint/js';
+import eslintComments from '@eslint-community/eslint-plugin-eslint-comments/configs';
 import rules from '../rules/base.js';
 
 export default [
   eslintJs.configs.recommended,
+  eslintComments.recommended,
   {
     plugins: {
       '@stylistic': stylistic,

--- a/legacy/configs/base.js
+++ b/legacy/configs/base.js
@@ -6,6 +6,7 @@ module.exports = {
   ],
   extends: [
     'eslint:recommended',
+    'plugin:@eslint-community/eslint-comments/recommended'
   ],
   rules: rules,
 };

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "node index.mjs && node legacy"
   },
   "dependencies": {
+    "@eslint-community/eslint-plugin-eslint-comments": "^4.4.1",
     "@eslint/js": "^9.17.0",
     "@stylistic/eslint-plugin": "^2.12.1",
     "@typescript-eslint/parser": "^8.19.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@eslint-community/eslint-plugin-eslint-comments':
+        specifier: ^4.4.1
+        version: 4.4.1(eslint@9.11.0)
       '@eslint/js':
         specifier: ^9.17.0
         version: 9.17.0
@@ -28,6 +31,12 @@ importers:
         version: 8.19.1(eslint@9.11.0)(typescript@5.6.2)
 
 packages:
+
+  '@eslint-community/eslint-plugin-eslint-comments@4.4.1':
+    resolution: {integrity: sha512-lb/Z/MzbTf7CaVYM9WCFNQZ4L1yi3ev2fsFPF99h31ljhSEyUoyEsKsNWiU+qD1glbYTDJdqgyaLKtyTkkqtuQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
 
   '@eslint-community/eslint-utils@4.4.0':
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
@@ -1166,6 +1175,12 @@ packages:
     engines: {node: '>=10'}
 
 snapshots:
+
+  '@eslint-community/eslint-plugin-eslint-comments@4.4.1(eslint@9.11.0)':
+    dependencies:
+      escape-string-regexp: 4.0.0
+      eslint: 9.11.0
+      ignore: 5.3.2
 
   '@eslint-community/eslint-utils@4.4.0(eslint@9.11.0)':
     dependencies:

--- a/rules/base.js
+++ b/rules/base.js
@@ -40,4 +40,7 @@ module.exports = {
   'no-prototype-builtins': 'off',
   'no-self-compare': 'error',
   'object-curly-spacing': ['error', 'always'],
+
+  // ESLint comments - https://eslint-community.github.io/eslint-plugin-eslint-comments/
+  '@eslint-community/eslint-comments/require-description': 'error',
 };


### PR DESCRIPTION
- Adds all rules defined at [Best Practices](https://eslint-community.github.io/eslint-plugin-eslint-comments/rules/#best-practices) + [require-description](https://eslint-community.github.io/eslint-plugin-eslint-comments/rules/require-description.html)
- [`ban-ts-comment`](https://typescript-eslint.io/rules/ban-ts-comment/) is already included by the [`recommended-type-checked`](https://typescript-eslint.io/users/configs#recommended-type-checked) config of [typescript-eslint](https://typescript-eslint.io/)

Closes #3 